### PR TITLE
Set hierarchyMode: hierarchicalQuota

### DIFF
--- a/foo-corp/system/resourcequota-sync.yaml
+++ b/foo-corp/system/resourcequota-sync.yaml
@@ -6,5 +6,6 @@ spec:
   groups:
   - kinds:
     - kind: ResourceQuota
+      hierarchyMode: hierarchicalQuota
       versions:
       - version: v1


### PR DESCRIPTION
Since the default was changed to inherit, foo-corp is now broken. The decision is just to override the default. That way, foo-corp still demonstrates hierarchical quota inheritance.